### PR TITLE
improve API design

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ plugins: [
         {
           resolve: 'gatsby-remark-toc',
           options: {
-            header: 'Table of Contents', // the custom header text
+            header: {
+              text: 'Table of Contents', // the custom header text
+              depth: 2 // the custom depth of header
+            },
+            /**
+             * or, alternatively, you can only specify header text
+             * this way, depth will be set to 2 by default
+             */
+            // header: 'Table of Contents',
             include: [
               'content/**/*.md' // an include glob to match against
             ]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ plugins: [
 
 Use the `orderedList` option if you want to change the list type from `<ul>` to `<ol>`.
 
+Meanwhile, you can specify a wrapper container for table of contents:
+
+```js
+// in your gatsby-config.js
+plugins: [
+  {
+    resolve: 'gatsby-transformer-remark',
+    options: {
+      plugins: [
+        {
+          resolve: 'gatsby-remark-toc',
+          options: {
+            header: 'Table of Contents', // the custom header text
+            wrapper: {
+              name: 'aside', // tagName of wrapper component
+              properties: {
+                // attributes of wrapper component
+                class: 'custom-class-here'
+                // you can add more here, such as aria-hidden: true, etc.
+              }
+            },
+            // or, alternatively you can simply pass a string here, which will be used as tagName
+            // wrapper: 'aside',
+            include: [
+              'content/**/*.md' // an include glob to match against
+            ]
+          }
+        }
+      ]
+    }
+  }
+];
+```
+
 Additionally, you can pass custom options directly to [mdast-util-toc][mdast-util-toc] like so:
 
 ```js

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -195,7 +195,7 @@ describe('custom behavior', () => {
     expect(toc.children).toHaveLength(3);
   });
 
-  test('it allows for a wrapper', () => {
+  test('it allows for adding a wrapper container of toc', () => {
     let markdownNode = getMarkdownNode(
       `
 # hello world
@@ -208,13 +208,41 @@ describe('custom behavior', () => {
 
     addToc(markdownNode, {
       include: ['content/*.md'],
-      wrappingWithSection: true
+      wrapper: 'aside'
     });
 
     const [wrapper] = markdownNode.markdownAST.children;
 
     expect(wrapper.type).toBe('section');
-    expect(wrapper.data.hProperties.class).toBe('gatsby-remark-toc');
+    expect(wrapper.data.hName).toBe('aside');
+  });
+
+  test('it allows for a wrapper with rich options', () => {
+    let markdownNode = getMarkdownNode(
+      `
+# hello world
+## Test
+### Another
+#### Hi
+  `,
+      'content/example.md'
+    );
+
+    addToc(markdownNode, {
+      include: ['content/*.md'],
+      wrapper: {
+        name: 'aside',
+        properties: {
+          class: 'custom-class'
+        }
+      }
+    });
+
+    const [wrapper] = markdownNode.markdownAST.children;
+
+    expect(wrapper.type).toBe('section');
+    expect(wrapper.data.hName).toBe('aside');
+    expect(wrapper.data.hProperties.class).toBe('custom-class');
   });
 
   test('it allows for headerDepth', () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -245,7 +245,7 @@ describe('custom behavior', () => {
     expect(wrapper.data.hProperties.class).toBe('custom-class');
   });
 
-  test('it allows for headerDepth', () => {
+  test('it allows for customizing depth of header', () => {
     let markdownNode = getMarkdownNode(
       `
 # hello world
@@ -258,7 +258,10 @@ describe('custom behavior', () => {
 
     addToc(markdownNode, {
       include: ['content/*.md'],
-      headerDepth: 3
+      header: {
+        text: 'Table of Contents',
+        depth: 3
+      }
     });
 
     const [heading] = markdownNode.markdownAST.children;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = function generateTOCNodes(
     useExistingHeader = false,
     orderedList = false,
     headerDepth = 2,
-    wrappingWithSection = false,
+    wrapper = undefined,
     mdastUtilTocOptions = {}
   }
 ) {
@@ -63,15 +63,14 @@ module.exports = function generateTOCNodes(
     toc
   ].filter(Boolean);
 
-  const tocSection = wrappingWithSection
+  const tocSection = wrapper
     ? [
         {
           type: 'section',
           data: {
-            hProperties: {
-              'aria-hidden': true,
-              class: 'gatsby-remark-toc'
-            }
+            hName: typeof wrapper === 'string' ? wrapper : wrapper.name,
+            hProperties:
+              typeof wrapper === 'string' ? undefined : wrapper.properties
           },
           children: nodes
         }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ module.exports = function generateTOCNodes(
     header = 'Table of Contents',
     useExistingHeader = false,
     orderedList = false,
-    headerDepth = 2,
     wrapper = undefined,
     mdastUtilTocOptions = {}
   }
@@ -23,10 +22,16 @@ module.exports = function generateTOCNodes(
     return;
   }
 
+  let headerText;
+  if (typeof header === 'string') {
+    headerText = header;
+  } else if (typeof header.text === 'string') {
+    headerText = header.text;
+  }
   const index = markdownAST.children.findIndex(node => {
     if (useExistingHeader) {
       if (node.type === 'heading') {
-        return node.children.findIndex(child => child.value === header) + 1;
+        return node.children.findIndex(child => child.value === headerText) + 1;
       }
       return false;
     }
@@ -50,13 +55,13 @@ module.exports = function generateTOCNodes(
   toc.ordered = orderedList;
 
   const nodes = [
-    header && {
+    headerText && {
       type: 'heading',
-      depth: headerDepth,
+      depth: typeof header.depth === 'number' ? header.depth : 2,
       children: [
         {
           type: 'text',
-          value: header
+          value: headerText
         }
       ]
     },


### PR DESCRIPTION
Hi, I modified new API design in the following ways:

1. Since it's allowed to add class to wrapper, I think it's also a good idea if wrapper's tagName is as well configurable (so that one can use `aside` instead of `div` or `section` for table of contents)
2. Not very sure if `'aria-hidden'=true` by default is a good idea, better leave this configuration to users
3. Merge header depth and header text into `header` attribute, makes API looking similar